### PR TITLE
ci: add pull request checks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,56 @@
+name: CI
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+
+jobs:
+  web:
+    name: web
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Lint
+        run: npm run lint
+
+      - name: Build
+        run: npm run build
+
+  infra:
+    name: infra
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: infra
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+          cache-dependency-path: infra/package-lock.json
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build
+        run: npm run build
+
+      - name: Test
+        run: npx jest --watchman=false


### PR DESCRIPTION
## 概要
- Pull Request と `main` への push 時に実行される GitHub Actions CI を追加
- Web アプリ側と infra 側のチェックを別 job として実行するようにした

## 変更内容
- `.github/workflows/ci.yml` を追加
- `web` job で `npm ci`、`npm run lint`、`npm run build` を実行
- `infra` job で `infra/` 配下の `npm ci`、`npm run build`、`npx jest --watchman=false` を実行
- root と `infra/` それぞれで npm cache を利用する設定を追加

## 確認
- `npm run lint`: 成功
- `npm run build`: 成功
- `cd infra && npm run build`: 成功
- `cd infra && npx jest --watchman=false`: 成功

## 補足
- 現在の `main` に存在する npm script だけをCI対象にしています。
- `typecheck` や `test:static` は、portfolio刷新側の変更が取り込まれた後に追加する想定です。